### PR TITLE
Replaced generic header due to OS conflicts

### DIFF
--- a/helpers.hpp
+++ b/helpers.hpp
@@ -1,7 +1,11 @@
 #ifndef _HELPERS_HPP
 #define _HELPERS_HPP
 
-#include <bits/stdc++.h>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <fstream>
 
 using namespace std;
 


### PR DESCRIPTION
\#include \<bits/stdc++.h> broken up into:
\#include \<vector>
\#include \<string>
\#include \<iostream>
\#include \<algorithm>
\#include \<fstream>